### PR TITLE
docs: update contributing to run tests

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,4 +32,9 @@ The following steps will get you setup to contribute changes to this repo:
 
 3. Install dependencies by running `yarn`. LeanJS uses [Yarn (version 1)][yarn-version-1], so you should too. If you install using `npm`, unnecessary `package-lock.json` files will be generated.
 
-4. Verify you've got everything set up for local development by running `yarn test`
+4. Verify you've got everything set up for local development by running the test suite, you have to build the project first
+
+   ```bash
+   yarn build
+   yarn test
+   ```


### PR DESCRIPTION
Update the **setup** section in the **contributing** doc to run the test suite.

Note: `npm run lint` runs indefinitely.

_<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached

## Documentation / Examples

- [ ] Make sure the linting passes by running `npm run lint`
- [ ] The examples guidelines are followed from our contributing guidelines